### PR TITLE
Relay shuffle

### DIFF
--- a/src/common/mini_pytor/client.py
+++ b/src/common/mini_pytor/client.py
@@ -463,6 +463,7 @@ class Responder(BaseHTTPRequestHandler):
             return query["req"][0]
         return fallback
 
+
 class RelayData:
     """Relay data class"""
 
@@ -482,6 +483,7 @@ def main():
     server_address = ('', 27182)
     httpd = HTTPServer(server_address, Responder)
     httpd.serve_forever()
+
 
 if __name__ == "__main__":
     main()

--- a/src/common/mini_pytor/client.py
+++ b/src/common/mini_pytor/client.py
@@ -468,8 +468,9 @@ class Responder(BaseHTTPRequestHandler):
 class CustomHTTPServer:
     """Custom HTTP Server instance to inject directory IP"""
 
-    def __init__(self, directory_address = ("127.0.0.1", 50000)):
+    def __init__(self, directory_address=("127.0.0.1", 50000)):
         def handler(*args):
+            """Override the default handler to pass in the address"""
             Responder(directory_address, *args)
         server = HTTPServer(('', 27182), handler)
         server.serve_forever()

--- a/src/common/mini_pytor/client.py
+++ b/src/common/mini_pytor/client.py
@@ -6,6 +6,7 @@ import json
 import struct
 import socket
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from random import sample
 
 import urllib
 import requests
@@ -332,7 +333,7 @@ class Client:
         try:
             sock = intermediate_relays[0].sock
             sock.send(pickle.dumps(sending_cell))
-            recv_cell = sock.recv(8192)
+            recv_cell = sock.recv(4790)
             their_cell = pickle.loads(recv_cell)
             if util.CLIENT_DEBUG:
                 print("received cell")
@@ -351,7 +352,7 @@ class Client:
                     print("Information is being Streamed. ", file=sys.stderr)
                 summation = [their_cell.payload]
                 while their_cell.type == CellType.CONTINUE:
-                    recv_cell = sock.recv(8192)  # await answer
+                    recv_cell = sock.recv(4790)  # await answer
                     # you now receive a cell with encrypted payload.
                     their_cell = pickle.loads(recv_cell)
                     if util.CLIENT_DEBUG:
@@ -411,6 +412,8 @@ class Responder(BaseHTTPRequestHandler):
         my_client = Client()
         # Get references from directories.
         relay_list = Client.get_directory_items()
+        relay_list = sample(relay_list, 3)
+        print(relay_list)
         NUM_RELAYS = 3
         options = {
             0: my_client.first_connect,

--- a/src/common/mini_pytor/directory.py
+++ b/src/common/mini_pytor/directory.py
@@ -34,6 +34,7 @@ class DirectoryServer:
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         # now you have a signature of your own damned public key.
         # better be "" or it'll listen only on localhost
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.socket.bind(("", 50000))
         self.socket.listen(100)
 

--- a/src/common/mini_pytor/relay.py
+++ b/src/common/mini_pytor/relay.py
@@ -38,7 +38,7 @@ class Relay():
     CLIENTS = []
     CLIENT_SOCKS = []
 
-    def __init__(self, port_number, identity=None):
+    def __init__(self, port_number, identity=None, directory_address=("127.0.0.1", 50000)):
         pem_file = os.path.join(
             os.path.dirname(__file__),
             "privates/privatetest" + str(identity) + ".pem"
@@ -71,8 +71,7 @@ class Relay():
 
         self.directory_socket = socket.socket(
             socket.AF_INET, socket.SOCK_STREAM)
-        self.directory_socket.connect(
-            (socket.gethostbyname(socket.gethostname()), 50000))
+        self.directory_socket.connect(directory_address)
         # connect to the directory server.
         self.directory_socket.send(pickle.dumps(directorycell))
 
@@ -439,28 +438,27 @@ def main():
     """Main function"""
     # sys.argv = input("you know the drill. \n")  # added for my debug
     # sys.argv = sys.argv.split()  # added for console debug
-    if len(sys.argv) == 2:  # was 2 -> 1
+    if len(sys.argv) == 2 or len(sys.argv) == 4:
         identity = None
-        port = sys.argv[1]  # was 1 -> 0
+        port = sys.argv[1]
         if port == "a":
             port = 45000
-            identity = 0
+            identity = "0"
         elif port == "b":
             port = 45001
-            identity = 1
+            identity = "1"
         elif port == "c":
             port = 45002
-            identity = 2
+            identity = "2"
 
+        if len(sys.argv) == 4:
+            relay = Relay(int(port), identity, (sys.argv[2], int(sys.argv[3])))
+        relay = Relay(int(port), identity)
     else:
-        print("Usage: python relay.py [port]")
+        print("Usage: python relay.py [port] (directory ip) (directory port)")
         return
-    relay = Relay(int(port), identity)
-    # identity might be None, so change to "None" if it is.
-    if not identity:
-        identity = "None"
-    print("Started relay on "+str(port) + "with identity " + identity)
 
+    print("Started relay on "+str(port) + " with identity " + str(identity))
     while True:
         relay.run()
 

--- a/src/common/mini_pytor/relay.py
+++ b/src/common/mini_pytor/relay.py
@@ -437,11 +437,11 @@ class Relay():
 
 def main():
     """Main function"""
-    sys.argv = input("you know the drill. \n")  # added for my debug
-    sys.argv = sys.argv.split()  # added for console debug
-    if len(sys.argv) == 1:  # was 2 -> 1
+    # sys.argv = input("you know the drill. \n")  # added for my debug
+    # sys.argv = sys.argv.split()  # added for console debug
+    if len(sys.argv) == 2:  # was 2 -> 1
         identity = None
-        port = sys.argv[0]  # was 1 -> 0
+        port = sys.argv[1]  # was 1 -> 0
         if port == "a":
             port = 45000
             identity = 0
@@ -451,15 +451,15 @@ def main():
         elif port == "c":
             port = 45002
             identity = 2
-        else:  # remove after console debug is over.
-            port = int(port)  # remove after console debug is over
+
     else:
         print("Usage: python relay.py [port]")
         return
     relay = Relay(int(port), identity)
-    if not isinstance(identity, int):  # identity was a none-type
-        identity = 22222  # Optionally remove after console Debug is over.
-    print("Started relay on %d with identity %d" % (port, identity))
+    # identity might be None, so change to "None" if it is.
+    if not identity:
+        identity = "None"
+    print("Started relay on "+str(port) + "with identity " + identity)
 
     while True:
         relay.run()

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -44,7 +44,7 @@ const spawnClientAndServers = () => {
       electron.ipcRenderer.send('pid-msg', client.pid);
 
       resolve();
-    }, 3000);
+    }, 1000);
   });
 };
 


### PR DESCRIPTION
Shuffle added.
Also preserved commands for relay.
Reduced Client.py buffer size to prevent over reading bytes meant for another cell.
(max bytes of a cell is now 4790 during request.)
Relay.py now creates it's own key if you don't input "a", "b" or "c" as the default. (used to always take identity 3). 
Can be changed back to that by making Identity=3 or even a random number (within range of our PEM files) if required